### PR TITLE
Update Kafka protocol to work with uppercased CT header

### DIFF
--- a/lib/cloudevents/kafka_binding/v_1_0/decoder.ex
+++ b/lib/cloudevents/kafka_binding/v_1_0/decoder.ex
@@ -78,11 +78,11 @@ defmodule Cloudevents.KafkaBinding.V_1_0.Decoder do
   # ---
 
   defp content_type(headers, kafka_body) do
-    content_type = for({"content-type", content_type} <- headers, do: content_type)
+    content_type = Enum.find(headers, &(&1 |> elem(0) |> String.downcase() == "content-type"))
 
-    if length(content_type) == 1 do
+    if content_type do
       content_type
-      |> hd()
+      |> elem(1)
       |> String.downcase()
     else
       case kafka_body do

--- a/test/kafka/binding_1_0/deserialize_format_1_0_test.exs
+++ b/test/kafka/binding_1_0/deserialize_format_1_0_test.exs
@@ -22,6 +22,25 @@ defmodule Cloudevents.Kafka.Binding_1_0.DeserializeFormat_1_0_Test do
     assert event.data == "this is the content"
   end
 
+  test "Payload in body, context attributes in the header, Content-Type with upper case" do
+    body = "this is the content"
+
+    headers = %{
+      "Content-Type" => "text/plain",
+      "ce_specversion" => "1.0",
+      "ce_type" => "some-type",
+      "ce_source" => "some-source",
+      "ce_id" => "1"
+    }
+
+    assert {:ok, event} = Cloudevents.from_kafka_message(body, headers)
+    assert event.type == "some-type"
+    assert event.source == "some-source"
+    assert event.id == "1"
+    assert event.datacontenttype == "text/plain"
+    assert event.data == "this is the content"
+  end
+
   test "A JSON payload in the body is decoded" do
     body = """
     {


### PR DESCRIPTION
Updated content type handler in Kafka protocol to also work with upper case format. Test case should cover it.