### PR TITLE
Bump typed_struct to 0.3.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule Cloudevents.MixProject do
       # Run all static code checks via `mix check`:
       {:ex_check, ">= 0.11.0", only: :dev, runtime: false},
       # A library for defining structs with a type without writing boilerplate code:
-      {:typed_struct, "~> 0.2.0"},
+      {:typed_struct, "~> 0.3.0"},
       # JSON parser:
       {:jason, "~> 1.2"},
       # Avro encoding/decoding:

--- a/mix.lock
+++ b/mix.lock
@@ -17,5 +17,5 @@
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "snappyer": {:hex, :snappyer, "1.2.8", "201ce9067a33c71a6a5087c0c3a49a010b17112d461e6df696c722dcb6d0934a", [:rebar3], [], "hexpm", "35518e79a28548b56d8fd6aee2f565f12f51c2d3d053f9cfa817c83be88c4f3d"},
-  "typed_struct": {:hex, :typed_struct, "0.2.1", "e1993414c371f09ff25231393b6430bd89d780e2a499ae3b2d2b00852f593d97", [:mix], [], "hexpm", "8f5218c35ec38262f627b2c522542f1eae41f625f92649c0af701a6fab2e11b3"},
+  "typed_struct": {:hex, :typed_struct, "0.3.0", "939789e3c1dca39d7170c87f729127469d1315dcf99fee8e152bb774b17e7ff7", [:mix], [], "hexpm", "c50bd5c3a61fe4e198a8504f939be3d3c85903b382bde4865579bc23111d1b6d"},
 }


### PR DESCRIPTION
A dependency override is needed when combined with other libraries that depend on the newer `typed_struct`. Upgrading to the next minor solves the problem.