### PR TITLE
Make avrora optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,14 @@ Use `Cloudevents.from_map/1` to create your first Cloudevent and see its JSON re
 
 If you're dealing with HTTP requests, `Cloudevents.from_http_message/2`, `Cloudevents.to_http_binary_message/1` and `Cloudevents.to_http_structured_message/2` are your friends.
 
-If you need Avro, you need to add `Cloudevents` to your supervisor:
+If you need Avro, you need to add `avrora` to your dependency list:
+```elixir
+def deps do
+  [{:avrora, "~> 0.21"}]
+end
+```
+
+Then, you need to add `Cloudevents` to your supervisor:
 
 ```elixir
 children = [

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Cloudevents.MixProject do
     [
       app: :cloudevents,
       description: description(),
-      version: "0.5.2",
+      version: "0.6.0",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -43,7 +43,7 @@ defmodule Cloudevents.MixProject do
       # JSON parser:
       {:jason, "~> 1.2"},
       # Avro encoding/decoding:
-      {:avrora, "~> 0.21"}
+      {:avrora, "~> 0.21", optional: true}
     ]
   end
 


### PR DESCRIPTION
Fixes #9 

**Note**: I've bumped the version in this PR to `0.6.0` to denote that it's a breaking change. I'm happy to back that version bump out if you prefer to bump versions in separate PRs.

This PR makes `avrora` an optional dependency for elixir projects that don't need Avro bindings. According to https://hexdocs.pm/mix/1.13/Mix.Tasks.Deps.html, making a dependency optional will always build it for this project (cloudevents-ex) but other projects that depend on this library will not include avrora by default. In the case where you do need avro bindings, you simply need to include `avrora` in the dependency list. I added this to the README to indicate the necessary change